### PR TITLE
Update GLTFExporter.js

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -28,6 +28,22 @@ import {
 import { decompress } from './../utils/TextureUtils.js';
 
 
+
+/**
+* @param  {String} validDrawImageType input format
+* validDrawImageType represents the types allowed in context.drawImage()
+*/
+
+const validDrawImageType = {
+	CSSImageValue: true,
+	HTMLCanvasElement: true,
+	HTMLVideoElement: true,
+	ImageBitmap: true,
+	OffscreenCanvas: true,
+	SVGImageElement: true,
+	VideoFrame: true,
+}
+
 /**
  * The KHR_mesh_quantization extension allows these extra attribute component types
  *
@@ -1280,10 +1296,8 @@ class GLTFWriter {
 
 				ctx.putImageData( new ImageData( data, image.width, image.height ), 0, 0 );
 
-			} else {
-
+			} else if (validDrawImageType[typeof image]) {
 				ctx.drawImage( image, 0, 0, canvas.width, canvas.height );
-
 			}
 
 			if ( options.binary === true ) {


### PR DESCRIPTION
Added type check so drawImage() would not be called with invalid type

Related issue: #[26992](https://github.com/mrdoob/three.js/issues/26992)

**Description**

ctx.drawImage(image, 0, 0) Does not check if image is a valid type or even confirms if the image is not undefined. 

This PR seeks to prevent a crash in the case of exporting to glb without any textures.

https://www.filer.dev/convert/blend-to-glb

Filer uses GLTFExporter to convert blend files into glb and gltf format.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [www.filer.dev](https://www.filer.dev/convert/blend-to-glb)*
